### PR TITLE
Add gnome-teminal port to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ _Oceanic Next_ was also ported to:
 - [x] [Vim](https://github.com/yosiat/oceanic-next-vim) (thanks to [Yosi Attias](https://github.com/yosiat))
 - [x] [XCode](https://github.com/dmcrodrigues/Oceanic-Next-Xcode-Theme) (thanks to [David Rodrigues](https://github.com/dmcrodrigues))
 - [x] [iTerm2](https://github.com/mhartington/oceanic-next-iterm) (thanks to [Mike Hartington](https://github.com/mhartington))
+- [x] [gnome-terminal][https://github.com/denysdovhan/oceanic-next-gnome-terminal] (thanks to [Denys Dovhan](https://github.com/denysdovhan))
 - [x] [Eclipse](http://eclipsecolorthemes.org/?view=theme&id=35308) (thanks to [John Louderback](https://github.com/JohnLouderback))
 - [x] [JetBrains](https://github.com/minwe/oceanic-next-jetbrains) (thanks to [Minwe LUO](https://github.com/minwe))
 


### PR DESCRIPTION
Hi!
I've made port this theme on gnome-terminal. So, now it works on Ubuntu, Fedora, elementaryOS or whatever that use gnome-terminal.

It looks like this:

![](https://cloud.githubusercontent.com/assets/3459374/9465490/b92dfea8-4b35-11e5-81f5-0b8e421e9ddc.png)

Look here — [oceanic-next-gnome-terminal](https://github.com/denysdovhan/oceanic-next-gnome-terminal/).
