### PR TITLE
Add active guide style to YAML file. Add italic attributes to support fonts like Operator Mono.

### DIFF
--- a/Oceanic Next.YAML-tmTheme
+++ b/Oceanic Next.YAML-tmTheme
@@ -21,6 +21,9 @@ settings:
     invisibles: '#65737e'
     lineHighlight: '#65737e55'
     selection: '#4f5b66'
+    guide: '#c0c5ce'
+    activeGuide: '#FAC863'
+    stackGuide: '#65737E'
 
 - name: Comments
   scope: comment, punctuation.definition.comment
@@ -157,4 +160,9 @@ settings:
   scope: source.js constant.other.object.key.js string.unquoted.label.js
   settings:
     foreground: '#EC5F67'
+    fontStyle: italic
+
+- name: Italic HTML attribute names
+  scope: entity.other.attribute-name.html, entity.other.attribute-name.event.html, entity.other.attribute-name.id.html, entity.other.attribute-name.tag.jade, constant.other.symbol.ruby
+  settings:
     fontStyle: italic

--- a/Oceanic Next.tmTheme
+++ b/Oceanic Next.tmTheme
@@ -28,18 +28,24 @@
 		<dict>
 			<key>settings</key>
 			<dict>
+				<key>activeGuide</key>
+				<string>#FAC863</string>
 				<key>background</key>
 				<string>#1B2B34</string>
 				<key>caret</key>
 				<string>#c0c5ce</string>
 				<key>foreground</key>
 				<string>#CDD3DE</string>
+				<key>guide</key>
+				<string>#c0c5ce</string>
 				<key>invisibles</key>
 				<string>#65737e</string>
 				<key>lineHighlight</key>
 				<string>#65737e55</string>
 				<key>selection</key>
 				<string>#4f5b66</string>
+				<key>stackGuide</key>
+				<string>#65737E</string>
 			</dict>
 		</dict>
 		<dict>
@@ -323,6 +329,17 @@
 				<string>italic</string>
 				<key>foreground</key>
 				<string>#EC5F67</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Italic HTML attribute names</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name.html, entity.other.attribute-name.event.html, entity.other.attribute-name.id.html, entity.other.attribute-name.tag.jade, constant.other.symbol.ruby</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
This pull request contains @Thr1ve's changes added via the YAML file as you requested. I have also added italic HTML attributes to support fonts like Operator Mono, which, in hindsight, I probably should make a separate pull request. Let me know if you'd prefer I do this.
