### PR TITLE
Add Sequel Pro to ports list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ _Oceanic Next_ was also ported to:
 - [x] [fish shell (VI keybinding)](https://github.com/Jim-Zenn/fish-theme-oceanic-next-vi) (thanks to [Jim Zenn](https://github.com/Jim-Zenn))
 - [x] [Emacs](https://github.com/terry3/oceanic-theme) (thanks to [Tengfei Guo](https://github.com/terry3))
 - [x] [macOS Terminal](https://github.com/robinbentley/oceanic-next-macos-terminal) (thanks to [Robin Bentley](https://github.com/robinbentley))
+- [x] [Sequel Pro](https://github.com/JodusNodus/oceanic-next-sequel-pro) (thanks to [Thomas Billiet](https://github.com/JodusNodus))
 
 You may also look at [base16-oceanic-next](https://github.com/wbinnssmith/base16-oceanic-next) - This project generates the Oceanic Next color scheme for a variety of text editors using base16-builder.
 


### PR DESCRIPTION
I love the theme and use it everyday in all my editors en terminals but i still missed one for [Sequel Pro](http://www.sequelpro.com/) so i made one.

[Oceanic Next for Sequel Pro](https://github.com/JodusNodus/oceanic-next-sequel-pro)

