### PR TITLE
Add new color entry for block caret

### DIFF
--- a/Oceanic Next.YAML-tmTheme
+++ b/Oceanic Next.YAML-tmTheme
@@ -17,6 +17,7 @@ settings:
 - settings:
     background: '#1B2B34'
     caret: '#c0c5ce'
+    blockCaret: '#c0c5ce'
     foreground: '#CDD3DE'
     invisibles: '#65737e'
     lineHighlight: '#65737e55'

--- a/Oceanic Next.tmTheme
+++ b/Oceanic Next.tmTheme
@@ -34,6 +34,8 @@
 				<string>#1B2B34</string>
 				<key>caret</key>
 				<string>#c0c5ce</string>
+				<key>blockCaret</key>
+				<string>#c0c5ce</string>
 				<key>foreground</key>
 				<string>#CDD3DE</string>
 				<key>guide</key>


### PR DESCRIPTION
This change adds a new entry to the list of colors to support the `block_caret` setting introduced in [Sublime Text 3.2](https://www.sublimetext.com/blog/articles/sublime-text-3-point-2).